### PR TITLE
Patch submodules and add first unittest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,19 @@
+import sys
+from unittest.mock import MagicMock
+
+
+sys.modules["anki"] = MagicMock()
+sys.modules["anki.hooks"] = MagicMock()
+sys.modules["anki.stdmodels"] = MagicMock()
+sys.modules["anki.lang"] = MagicMock()
+sys.modules["anki.find"] = MagicMock()
+sys.modules["aqt"] = MagicMock()
+sys.modules["aqt.qt"] = MagicMock()
+sys.modules["aqt.utils"] = MagicMock()
+sys.modules["korean.lib.gtts"] = MagicMock()
+sys.modules["korean.lib.gtts.tts"] = MagicMock()
+sys.modules["korean.lib.navertts"] = MagicMock()
+sys.modules["korean.lib.navertts.tts"] = MagicMock()
+sys.modules["korean.lib.kengdic"] = MagicMock()
+sys.modules["korean.ui"] = MagicMock()
+sys.modules["korean.lib"] = MagicMock()

--- a/tests/test_edit_functions.py
+++ b/tests/test_edit_functions.py
@@ -1,0 +1,9 @@
+import pytest
+from korean.edit_functions import add_diaeresis
+
+
+@pytest.mark.parametrize(
+    "test_str, expected_str", [("v", "ü"), ("very", "üery"), ("vlo", "ülo")]
+)
+def test_add_diaeresis(test_str, expected_str):
+    assert add_diaeresis(test_str) == expected_str


### PR DESCRIPTION
Mocks out relevant submodules not used during unittest and adds a simple test for diaresis.

Follows mocking procedures here: https://github.com/luoliyan/chinese-support-redux/blob/master/tests/__init__.py#L29

Related to #8 