### PR TITLE
Run loadMenu hook only on gui start, not on every profile load

### DIFF
--- a/korean/__init__.py
+++ b/korean/__init__.py
@@ -19,8 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from anki.hooks import addHook
-from aqt import mw, addons
+from aqt import mw, addons, gui_hooks
 from aqt.utils import showInfo
 
 from . import edit
@@ -28,7 +27,7 @@ from .models import advanced
 from .models import basic
 from .ui import loadMenu
 
-addHook("profileLoaded", loadMenu)
+gui_hooks.main_window_did_init.append(loadMenu)
 
 # hack to force updates
 mgr = mw.addonManager


### PR DESCRIPTION
Currently the menu hook runs on every profile switch which means you end up with something like this when you switch profiles a few times:

![Screenshot 2024-02-23 150020](https://github.com/scottgigante/korean-support/assets/2419591/145256cb-935b-4de7-8821-c893831c33ea)


Changed it to use the `main_window_did_init` hook which only runs once. These hooks were introduced in Anki 2.1.20 which came out 4 years ago so the minimum version on ankiweb might need to be changed.