### PR TITLE
Editbutton Color

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ For bug reports, issues and feature requests, and to discuss contributing to the
 * [Issue Tracker](https://github.com/scottgigante/korean-support/issues)
 * [Forum support thread](https://anki.tenderapp.com/discussions/add-ons/22781-korean-support-add-on)
 * [Forum development thread](https://anki.tenderapp.com/discussions/add-ons/22783-korean-support-add-on-development)
+  
+
+### Migration
+
+With newer Anki Versions the way comments are handled changed. The plugin tries to update these templates automatically, but might detect false positives. In this case manual migration is recommended. 
+
+Click **Browse**, select a card with the correct template, select **Cards**, go to the **Back Template** and replace `<!-- {{Sound}}-->` with `<div class=korean-support-sound>{{Sound}}</div>`, then click on **Styling** and add `.korean-support-sound { display: none; }` to the bottom as a new line.
 
 ### To-do
 
@@ -32,6 +39,9 @@ For bug reports, issues and feature requests, and to discuss contributing to the
 * Google Translate
 
 ### History
+
+### v0.20-beta
+* Migrate sound templates to work with newer Anki
 
 ### v0.19-beta (2024.05.25)
 * Remove deprecated anki calls and fix version in about section

--- a/korean/__init__.py
+++ b/korean/__init__.py
@@ -26,8 +26,10 @@ from . import edit
 from .models import advanced
 from .models import basic
 from .ui import loadMenu
+from .migration import run_migrations
 
 gui_hooks.main_window_did_init.append(loadMenu)
+gui_hooks.collection_did_load.append(run_migrations)
 
 # hack to force updates
 mgr = mw.addonManager

--- a/korean/__init__.py
+++ b/korean/__init__.py
@@ -31,18 +31,23 @@ from .migration import run_migrations
 gui_hooks.main_window_did_init.append(loadMenu)
 gui_hooks.collection_did_load.append(run_migrations)
 
-# hack to force updates
-mgr = mw.addonManager
-for dir in mgr.allAddons():
-    if mgr.addonName(dir) == "Korean Support":
-        addon_id = dir
-        break
-try:
-    updated = str(addon_id) in mgr.checkForUpdates()
-except:
-    updated = False
 
-if updated:
-    showInfo(
-        "An update is available for Korean Support. Please update it by going to Tools -> Addons -> Check for Updates."
-    )
+# hack to force updates
+def check_for_updates():
+    mgr = mw.addonManager
+    for dir in mgr.allAddons():
+        if mgr.addonName(dir) == "Korean Support":
+            addon_id = dir
+            break
+    try:
+        updated = str(addon_id) in mgr.checkForUpdates()
+    except:
+        updated = False
+
+    if updated:
+        showInfo(
+            "An update is available for Korean Support. Please update it by going to Tools -> Addons -> Check for Updates."
+        )
+
+
+gui_hooks.main_window_did_init.append(check_for_updates)

--- a/korean/_version.py
+++ b/korean/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.19-beta"
+__version__ = "0.20-beta"

--- a/korean/config.py
+++ b/korean/config.py
@@ -5,15 +5,13 @@
 # Copyright © 2018 Scott Gigante <scottgigante@gmail.com>
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 
-from anki.hooks import addHook
-from aqt import mw
-
+from aqt import mw, gui_hooks
 
 class ConfigManager:
     def __init__(self):
         self.tips = []
         self.options = mw.addonManager.getConfig(__name__)
-        addHook("unloadProfile", self.save)
+        gui_hooks.profile_will_close.append(self.save)
 
     def save(self):
         try:

--- a/korean/config.py
+++ b/korean/config.py
@@ -7,6 +7,7 @@
 
 from aqt import mw, gui_hooks
 
+
 class ConfigManager:
     def __init__(self):
         self.tips = []

--- a/korean/edit.py
+++ b/korean/edit.py
@@ -5,8 +5,7 @@
 # Copyright © 2018 Scott Gigante <scottgigante@gmail.com>
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 
-from anki.hooks import addHook
-from aqt import mw
+from aqt import mw, gui_hooks
 
 from .config import korean_support_config as config
 from .edit_behavior import updateFields
@@ -14,9 +13,9 @@ from .edit_behavior import updateFields
 
 class EditManager:
     def __init__(self):
-        addHook("setupEditorButtons", self.setupButton)
-        addHook("loadNote", self.updateButton)
-        addHook("editFocusLost", self.onFocusLost)
+        gui_hooks.editor_did_init_buttons.append(self.setupButton)
+        gui_hooks.editor_did_load_note.append(self.updateButton)
+        gui_hooks.editor_did_unfocus_field.append(self.onFocusLost)
 
     def setupButton(self, buttons, editor):
         self.editor = editor
@@ -79,6 +78,6 @@ def appendToneStyling(editor):
     editor.web.eval(js)
 
 
-addHook("loadNote", appendToneStyling)
+gui_hooks.editor_did_load_note.append(appendToneStyling)
 
 EditManager()

--- a/korean/edit.py
+++ b/korean/edit.py
@@ -31,7 +31,7 @@ class EditManager:
             toggleable=True,
         )
 
-        return buttons + [button]
+        buttons.append(button)
 
     def onToggle(self, editor):
         self.buttonOn = not self.buttonOn

--- a/korean/edit_functions.py
+++ b/korean/edit_functions.py
@@ -49,7 +49,7 @@ def silhouette(hangul):
             r += i + " "
         return r[:-1]
 
-    hangul_unicode = "[\u1100-\u11ff|\uAC00-\uD7AF|\u3130-\u318F]"
+    hangul_unicode = "[\u1100-\u11ff|\uac00-\ud7af|\u3130-\u318f]"
     hangul = re.sub("{}+".format(hangul_unicode), insert_spaces, hangul)
     txt = re.sub(hangul_unicode, "_", hangul)
     return txt

--- a/korean/microsofttranslator/__init__.py
+++ b/korean/microsofttranslator/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    __init__
+__init__
 
-    A translator using the micrsoft translation engine documented here:
+A translator using the micrsoft translation engine documented here:
 
-    http://msdn.microsoft.com/en-us/library/ff512419.aspx
+http://msdn.microsoft.com/en-us/library/ff512419.aspx
 
 """
 

--- a/korean/migration.py
+++ b/korean/migration.py
@@ -1,0 +1,57 @@
+from aqt import mw
+from aqt.utils import showInfo, askUser, showText
+
+
+def run_migrations(col):
+    migrate_templates_with_prompt(
+        "<!-- {{Sound}}-->",
+        "<div class=korean-support-sound>{{Sound}}</div>",
+        ".korean-support-sound { display: none; }",
+    )
+
+
+def migrate_templates_with_prompt(find_str, replace_str, css_snippet):
+    affected = []
+
+    for model in mw.col.models.all():
+        for template in model["tmpls"]:
+            for key in ["qfmt", "afmt"]:
+                if find_str in template[key]:
+                    affected.append((model["name"], template["name"]))
+                    break
+
+    if not affected:
+        return
+
+    summary = "\n".join([f"{m} → {t}" for m, t in affected])
+    if not askUser(
+        """<div>Due to a change in Anki, older Korean Support Plugin templates need to be migrated. <br> 
+                   The following templates contain the old style of templates:"""
+        f"<br><br>{summary}<br><br>"
+        """If any of these templates aren't used with the Korean Support plugin, please migrate your templates manually. 
+                   (See <a href='https://github.com/scottgigante/korean-support/blob/master/README.md#migration'>migration</a>)<br>
+                   Do you want to apply the migration?</div>""",
+        None,
+        False,
+        False,
+        None,
+        "Korean Support",
+    ):
+        return
+
+    for model in mw.col.models.all():
+        changed = False
+        for template in model["tmpls"]:
+            for key in ["qfmt", "afmt"]:
+                if find_str in template[key]:
+                    template[key] = template[key].replace(find_str, replace_str)
+                    changed = True
+        if css_snippet:
+            if css_snippet not in model["css"]:
+                model["css"] += f"\n{css_snippet}"
+                changed = True
+        if changed:
+            mw.col.models.save(model)
+
+    mw.col.reset()
+    showInfo("Migration complete. Templates updated.")

--- a/korean/models/advanced.py
+++ b/korean/models/advanced.py
@@ -50,13 +50,13 @@ def add_model(col):
     m = mm.new(model_name)
     # Add fields
     for f in fields_list:
-        fm = mm.newField(f)
+        fm = mm.new_field(f)
         mm.addField(m, fm)
-    t = mm.newTemplate("Recognition")
+    t = mm.new_template("Recognition")
     t["qfmt"] = recognition_front
     t["afmt"] = recognition_back
     mm.addTemplate(m, t)
-    t = mm.newTemplate("Recall")
+    t = mm.new_template("Recall")
     t["qfmt"] = recall_front
     t["afmt"] = recall_back
     mm.addTemplate(m, t)

--- a/korean/models/basic.py
+++ b/korean/models/basic.py
@@ -39,15 +39,15 @@ def add_model_simp(col):
     model = col.models.new(model_name)
     # Add fields
     for field_name in fields_list:
-        field = col.models.newField(field_name)
+        field = col.models.new_field(field_name)
         col.models.addField(model, field)
     # recognition card
-    t = col.models.newTemplate("Recognition")
+    t = col.models.new_template("Recognition")
     t["qfmt"] = recognition_front
     t["afmt"] = recognition_back
     col.models.addTemplate(model, t)
     # recall card
-    t = col.models.newTemplate("Recall")
+    t = col.models.new_template("Recall")
     t["qfmt"] = recall_front
     t["afmt"] = recall_back
     col.models.addTemplate(model, t)

--- a/korean/models/card_fields.py
+++ b/korean/models/card_fields.py
@@ -34,7 +34,7 @@ silhouette = "<div class=korean>{{Silhouette}}</span>"
 
 comment = "<div class=comment>{{Comment}}</span>"
 
-sound = "<!-- {{Sound}}-->"
+sound = "<div class=korean-support-sound>{{Sound}}</div>"
 
 front_side = """\
 {{FrontSide}}

--- a/korean/models/css.py
+++ b/korean/models/css.py
@@ -26,4 +26,5 @@ style = """\
 .note {color:gray;font-size:12pt;margin-top:20pt;}
 .hint {font-size:12pt;}
 .answer { background-color:bisque; border:dotted;border-width:1px}
+.korean-support-sound { display: none; }
 """


### PR DESCRIPTION
These patches require #48 as a base. 

The `toggleEditorButton` function has been removed from Anki at some point and as a result its harder to tell if the button is active or not. I've tried to patch this in the past but failed since I didn't realize that _addButton and addButton aren't the same function. Now the button is blue again when the addon is active so it's clearer to see.